### PR TITLE
kottsov.daniil/T3

### DIFF
--- a/kottsov.daniil/T3/main.cpp
+++ b/kottsov.daniil/T3/main.cpp
@@ -1,0 +1,4 @@
+int main()
+{
+  return 0;
+}

--- a/kottsov.daniil/T3/main.cpp
+++ b/kottsov.daniil/T3/main.cpp
@@ -49,7 +49,7 @@ int main(int args, char* fileinput[])
       }
       else if (std::string(ex.what())==std::string("invalid cmd"))
       {
-        std::cerr << "<INVALID COMMAND>" << '\n';
+        std::cout << "<INVALID COMMAND>" << '\n';
       }
       std::cin.clear();
       std::cin.ignore(std::numeric_limits<std::streamsize>::max(),'\n');

--- a/kottsov.daniil/T3/main.cpp
+++ b/kottsov.daniil/T3/main.cpp
@@ -1,4 +1,60 @@
-int main()
+#include "operations.h"
+#include "polygon.h"
+#include <fstream>
+#include <sstream>
+using namespace poly;
+
+int main(int args, char* fileinput[])
 {
+  using inputType = Polygon;
+  if (args!=2)
+  {
+    std::cerr << "invalid arguments\n";
+    return 1;
+  }
+  std::ifstream input(fileinput[1]);
+  std::istream::sentry ward(input);
+  if (!ward)
+  {
+    std::cerr << "ifstream failure\n";
+    return 1;
+  }
+  std::vector<inputType> vector;
+  while (!input.eof())
+  {
+    try
+    {
+      std::copy(
+        std::istream_iterator<inputType>(input),
+        std::istream_iterator<inputType>(),
+        std::back_inserter(vector)
+      );
+    }
+    catch (const std::logic_error& ex)
+    {
+      input.clear();
+      input.ignore(std::numeric_limits<std::streamsize>::max(),'\n');
+    }
+  }
+  while (!std::cin.eof())
+  {
+    try
+    {
+      ioUI(vector,std::cin,std::cout);
+    }
+    catch (const std::logic_error& ex)
+    {
+      if (std::string(ex.what())==std::string("istream failure"))
+      {
+        return 0;
+      }
+      else if (std::string(ex.what())==std::string("invalid cmd"))
+      {
+        std::cerr << "<INVALID COMMAND>" << '\n';
+      }
+      std::cin.clear();
+      std::cin.ignore(std::numeric_limits<std::streamsize>::max(),'\n');
+    }
+  }
   return 0;
 }

--- a/kottsov.daniil/T3/main.cpp
+++ b/kottsov.daniil/T3/main.cpp
@@ -21,15 +21,12 @@ int main(int args, char* fileinput[])
   std::vector<inputType> vector;
   while (!input.eof())
   {
-    try
-    {
-      std::copy(
-        std::istream_iterator<inputType>(input),
-        std::istream_iterator<inputType>(),
-        std::back_inserter(vector)
-      );
-    }
-    catch (const std::logic_error& ex)
+    std::copy(
+      std::istream_iterator<inputType>(input),
+      std::istream_iterator<inputType>(),
+      std::back_inserter(vector)
+    );
+    if (!input && !input.eof())
     {
       input.clear();
       input.ignore(std::numeric_limits<std::streamsize>::max(),'\n');

--- a/kottsov.daniil/T3/main.cpp
+++ b/kottsov.daniil/T3/main.cpp
@@ -13,8 +13,7 @@ int main(int args, char* fileinput[])
     return 1;
   }
   std::ifstream input(fileinput[1]);
-  std::istream::sentry ward(input);
-  if (!ward)
+  if (!input)
   {
     std::cerr << "ifstream failure\n";
     return 1;

--- a/kottsov.daniil/T3/operations.cpp
+++ b/kottsov.daniil/T3/operations.cpp
@@ -34,8 +34,6 @@ void poly::ioUI(std::vector<Polygon>& vector, std::istream& in, std::ostream& ou
   std::string operation;
   {
     using string = ExpressionIO;
-    using symbol = DefInput;
-    using number = NumberInput;
     in >> string{ operation };
     if (!in)
     {

--- a/kottsov.daniil/T3/operations.cpp
+++ b/kottsov.daniil/T3/operations.cpp
@@ -1,0 +1,523 @@
+#include "operations.h"
+
+std::istream& poly::operator>>(std::istream& in, ExpressionIO&& exp)
+{
+  std::istream::sentry ward(in);
+  if (!ward)
+  {
+    throw std::logic_error("istream failure");
+    return in;
+  }
+  in >> exp.ref;
+  if (!in)
+  {
+    throw std::logic_error("invalid exp");
+    return in;
+  }
+  return in;
+}
+void poly::ioUI(std::vector<Polygon>& vector, std::istream& in, std::ostream& out)
+{
+  std::istream::sentry ward(in);
+  if (!ward)
+  {
+    throw std::logic_error("istream failure");
+    return;
+  }
+  std::ostream::sentry warden(out);
+  if (!warden)
+  {
+    throw std::logic_error("ostream failure");
+    return;
+  }
+  iofmtguard fmtguard(out);
+  std::string operation;
+  {
+    using string = ExpressionIO;
+    using symbol = DefInput;
+    using number = NumberInput;
+    in >> string{ operation };
+    if (!in)
+    {
+      in.setstate(std::ios::failbit);
+      throw std::logic_error("invalid cmd");
+      return;
+    }
+    if (operation == "AREA")
+    {
+      std::string sub;
+      in >> string{ sub };
+      if (!in)
+      {
+        in.setstate(std::ios::failbit);
+        throw std::logic_error("invalid cmd");
+        return;
+      }
+      if (sub == "ODD")
+      {
+        out << std::setprecision(1) << std::fixed << getTotalArea(vector,1) << '\n';
+        return;
+      }
+      else if (sub == "EVEN")
+      {
+        out << std::setprecision(1) << std::fixed << getTotalArea(vector,0) << '\n';
+        return;
+      }
+      else if (sub == "MEAN")
+      {
+        out << std::setprecision(1) << std::fixed << getMeanArea(vector) << '\n';
+        return;
+      }
+      else
+      {
+        try
+        {
+          int num{ std::stoi(sub) };
+          out << std::setprecision(1) << std::fixed << getSpecArea(vector,num) << '\n';
+        }
+        catch (const std::invalid_argument& ex)
+        {
+          throw std::logic_error("invalid cmd");
+          return;
+        }
+      }
+    }
+    else if (operation == "MAX")
+    {
+      std::string sub;
+      in >> string{ sub };
+      if (!in)
+      {
+        in.setstate(std::ios::failbit);
+        throw std::logic_error("invalid cmd");
+        return;
+      }
+      if (sub == "AREA")
+      {
+        out << std::setprecision(1) << std::fixed << getMaxArea(vector) << '\n';
+        return;
+      }
+      else if (sub == "VERTEXES")
+      {
+        out << getMaxVert(vector) << '\n';
+        return;
+      }
+      else
+      {
+        throw std::logic_error("invalid cmd");
+        return;
+      }
+    }
+    else if (operation == "MIN")
+    {
+      std::string sub;
+      in >> string{ sub };
+      if (!in)
+      {
+        in.setstate(std::ios::failbit);
+        throw std::logic_error("invalid cmd");
+        return;
+      }
+      if (sub == "AREA")
+      {
+        out << std::setprecision(1) << std::fixed << getMinArea(vector) << '\n';
+        return;
+      }
+      else if (sub == "VERTEXES")
+      {
+        out << getMinVert(vector) << '\n';
+        return;
+      }
+      else
+      {
+        throw std::logic_error("invalid cmd");
+        return;
+      }
+    }
+    else if (operation == "COUNT")
+    {
+      std::string sub;
+      in >> string{ sub };
+      if (!in)
+      {
+        in.setstate(std::ios::failbit);
+        throw std::logic_error("invalid cmd");
+        return;
+      }
+      if (sub == "EVEN")
+      {
+        out << countTotal(vector,0) << '\n';
+        return;
+      }
+      else if (sub == "ODD")
+      {
+        out << countTotal(vector,1) << '\n';
+        return;
+      }
+      else
+      {
+        try
+        {
+          int num{ std::stoi(sub) };
+          out << countSpec(vector, num) << '\n';
+        }
+        catch(const std::invalid_argument& ex)
+        {
+          throw std::logic_error("invalid cmd");
+          return;
+        }
+      }
+    }
+    else if (operation == "RMECHO")
+    {
+      Polygon polygon;
+      in >> polygon;
+      if (!in)
+      {
+        in.setstate(std::ios::failbit);
+        throw std::logic_error("invalid cmd");
+        return;
+      }
+      out << rmecho(vector, polygon) << '\n';
+      return;
+    }
+    else if (operation == "SAME")
+    {
+      Polygon polygon;
+      in >> polygon;
+      if (!in)
+      {
+        in.setstate(std::ios::failbit);
+        throw std::logic_error("invalid cmd");
+        return;
+      }
+      out << same(vector, polygon) << '\n';
+      return;
+    }
+    else
+    {
+      in.setstate(std::ios::failbit);
+      throw std::logic_error("invalid cmd");
+      return;
+    }
+  }
+}
+double poly::getTotalArea(const std::vector<Polygon>& vector, bool type)
+{
+  struct calcArea
+  {
+    double operator()(bool r, double total, const Polygon& polygon)
+    {
+      if (polygon.polygon_.size() % 2 == r)
+      {
+        return total+getPolyArea(polygon);
+      }
+      else
+      {
+        return total;
+      }
+    }
+  };
+  double totalArea = std::accumulate(
+    vector.begin(),
+    vector.end(),
+    0.0,
+    std::bind(
+      calcArea(),
+      type,
+      std::placeholders::_1,
+      std::placeholders::_2
+    )
+  );
+  return totalArea;
+}
+double poly::getMeanArea(const std::vector<Polygon>& vector)
+{
+  struct calcArea
+  {
+    double operator()(double total,const Polygon& polygon)
+    {
+      return total+getPolyArea(polygon);
+    }
+  };
+  double area = std::accumulate(
+    vector.begin(),
+    vector.end(),
+    0.0,
+    std::bind(
+      calcArea(),
+      std::placeholders::_1,
+      std::placeholders::_2
+    )
+  );
+  return area/(static_cast<double>(vector.size()));
+}
+double poly::getSpecArea(const std::vector<Polygon>& vector, size_t num)
+{
+  struct calcArea
+  {
+    double operator()(size_t size, double total, const Polygon& polygon)
+    {
+      if (polygon.polygon_.size() == size)
+      {
+        return total+getPolyArea(polygon);
+      }
+      else
+      {
+        return total;
+      }
+    }
+  };
+  double totalArea = std::accumulate(
+    vector.begin(),
+    vector.end(),
+    0.0,
+    std::bind(
+      calcArea(),
+      num,
+      std::placeholders::_1,
+      std::placeholders::_2
+    )
+  );
+  return totalArea;
+}
+double poly::getMaxArea(const std::vector<Polygon>& vector)
+{
+  struct Comparator
+  {
+    double operator()(double max,const Polygon& polygon)
+    {
+      double area = getPolyArea(polygon);
+      if (area > max)
+      {
+        return area; 
+      }
+      else
+      {
+        return max;
+      }
+    }
+  };
+  double max = std::accumulate(
+    vector.begin(),
+    vector.end(),
+    0.0,
+    Comparator()
+  );
+  return max;
+}
+size_t poly::getMaxVert(const std::vector<Polygon>& vector)
+{
+  struct Comparator
+  {
+    size_t operator()(size_t max,const Polygon& polygon)
+    {
+      if (polygon.polygon_.size() > max)
+      {
+        return polygon.polygon_.size(); 
+      }
+      else
+      {
+        return max;
+      }
+    }
+  };
+  size_t max = std::accumulate(
+    vector.begin(),
+    vector.end(),
+    0,
+    Comparator()
+  );
+  return max;
+}
+double poly::getMinArea(const std::vector<Polygon>& vector)
+{
+  struct Comparator
+  {
+    double operator()(double min,const Polygon& polygon)
+    {
+      double area = getPolyArea(polygon);
+      if (area < min)
+      {
+        return area; 
+      }
+      else
+      {
+        return min;
+      }
+    }
+  };
+  double min = std::accumulate(
+    vector.begin(),
+    vector.end(),
+    std::numeric_limits<double>::max(),
+    Comparator()
+  );
+  return min;
+}
+size_t poly::getMinVert(const std::vector<Polygon>& vector)
+{
+  struct Comparator
+  {
+    size_t operator()(size_t min,const Polygon& polygon)
+    {
+      if (polygon.polygon_.size() < min)
+      {
+        return polygon.polygon_.size(); 
+      }
+      else
+      {
+        return min;
+      }
+    }
+  };
+  size_t min = std::accumulate(
+    vector.begin(),
+    vector.end(),
+    std::numeric_limits<size_t>::max(),
+    Comparator()
+  );
+  return min;
+}
+size_t poly::countTotal(const std::vector<Polygon>& vector, bool type)
+{
+  struct Calc
+  {
+    double operator()(bool r, double total, const Polygon& polygon)
+    {
+      if (polygon.polygon_.size() % 2 == r)
+      {
+        return ++total;
+      }
+      else
+      {
+        return total;
+      }
+    }
+  };
+  size_t amount = std::accumulate(
+    vector.begin(),
+    vector.end(),
+    0,
+    std::bind(
+      Calc(),
+      type,
+      std::placeholders::_1,
+      std::placeholders::_2
+    )
+  );
+  return amount;
+}
+size_t poly::countSpec(const std::vector<Polygon>& vector,size_t num)
+{
+  struct Calc
+  {
+    double operator()(size_t number, size_t total, const Polygon& polygon)
+    {
+      if (polygon.polygon_.size() == number)
+      {
+        return ++total;
+      }
+      else
+      {
+        return total;
+      }
+    }
+  };
+  double amount = std::accumulate(
+    vector.begin(),
+    vector.end(),
+    0,
+    std::bind(
+      Calc(),
+      num,
+      std::placeholders::_1,
+      std::placeholders::_2
+    )
+  );
+  return amount;
+}
+size_t poly::rmecho(std::vector<Polygon>& vector, const Polygon& plg)
+{
+  bool flag = false;
+  size_t counter = 0;
+  vector.erase(
+    std::remove_if(
+      vector.begin(),
+      vector.end(),
+      [&counter,&flag,plg](const Polygon& current)
+      {
+        if (!flag && plg == current)
+        {
+          flag = true;
+          return false;
+        }
+        else if (flag && current == plg)
+        {
+          counter++;
+          return true;
+        }
+        else if (flag && !(current == plg))
+        {
+          flag = false;
+          return false;
+        }
+        else {
+          return false;
+        }
+      }
+    ),
+    vector.end()
+  );
+  return counter;
+}
+size_t poly::same(const std::vector<Polygon>& vector, const Polygon& plg)
+{
+  struct directionalVector
+  {
+    int x_;
+    int y_;
+  };
+  struct pointComp
+  {
+    bool operator()(const directionalVector& dir, const Point& point1, const Point& point2)
+    {
+      return (dir.x_==(point1.x_-point2.x_)) && (dir.y_==(point1.y_-point2.y_));
+    }
+  };
+  size_t counter = std::accumulate(
+    vector.begin(),
+    vector.end(),
+    0,
+    [&plg](size_t total, const Polygon& poly)
+    {
+      if (plg.polygon_.size()!=poly.polygon_.size())
+      {
+        return total;
+      }
+      else
+      {
+        directionalVector direction = {
+          plg.polygon_[0].x_-poly.polygon_[0].x_,
+          plg.polygon_[0].y_-poly.polygon_[0].y_
+        };
+        if (std::equal(
+            plg.polygon_.cbegin(),
+            plg.polygon_.cend(),
+            poly.polygon_.cbegin(),
+            poly.polygon_.cend(),
+            std::bind(pointComp(),direction,std::placeholders::_1,std::placeholders::_2)
+          )
+        )
+        {
+          return ++total;
+        }
+        else
+        {
+          return total;
+        }
+      } 
+    }
+  );
+  return counter;
+}

--- a/kottsov.daniil/T3/operations.cpp
+++ b/kottsov.daniil/T3/operations.cpp
@@ -290,7 +290,7 @@ double poly::getMaxArea(const std::vector<Polygon>& vector)
       double area = getPolyArea(polygon);
       if (area > max)
       {
-        return area; 
+        return area;
       }
       else
       {
@@ -314,7 +314,7 @@ size_t poly::getMaxVert(const std::vector<Polygon>& vector)
     {
       if (polygon.polygon_.size() > max)
       {
-        return polygon.polygon_.size(); 
+        return polygon.polygon_.size();
       }
       else
       {
@@ -339,7 +339,7 @@ double poly::getMinArea(const std::vector<Polygon>& vector)
       double area = getPolyArea(polygon);
       if (area < min)
       {
-        return area; 
+        return area;
       }
       else
       {
@@ -363,7 +363,7 @@ size_t poly::getMinVert(const std::vector<Polygon>& vector)
     {
       if (polygon.polygon_.size() < min)
       {
-        return polygon.polygon_.size(); 
+        return polygon.polygon_.size();
       }
       else
       {
@@ -462,7 +462,8 @@ size_t poly::rmecho(std::vector<Polygon>& vector, const Polygon& plg)
           flag = false;
           return false;
         }
-        else {
+        else
+        {
           return false;
         }
       }
@@ -516,7 +517,7 @@ size_t poly::same(const std::vector<Polygon>& vector, const Polygon& plg)
         {
           return total;
         }
-      } 
+      }
     }
   );
   return counter;

--- a/kottsov.daniil/T3/operations.cpp
+++ b/kottsov.daniil/T3/operations.cpp
@@ -43,6 +43,11 @@ void poly::ioUI(std::vector<Polygon>& vector, std::istream& in, std::ostream& ou
     }
     if (operation == "AREA")
     {
+      if (vector.empty())
+      {
+        throw std::logic_error("invalid cmd");
+        return;
+      }
       std::string sub;
       in >> string{ sub };
       if (!in)
@@ -71,7 +76,14 @@ void poly::ioUI(std::vector<Polygon>& vector, std::istream& in, std::ostream& ou
         try
         {
           int num{ std::stoi(sub) };
-          out << std::setprecision(1) << std::fixed << getSpecArea(vector,num) << '\n';
+          if (num>2)
+          {
+            out << std::setprecision(1) << std::fixed << getSpecArea(vector,num) << '\n';
+          }
+          else
+          {
+            throw std::invalid_argument("smol");
+          }
         }
         catch (const std::invalid_argument& ex)
         {
@@ -82,6 +94,11 @@ void poly::ioUI(std::vector<Polygon>& vector, std::istream& in, std::ostream& ou
     }
     else if (operation == "MAX")
     {
+      if (vector.empty())
+      {
+        throw std::logic_error("invalid cmd");
+        return;
+      }
       std::string sub;
       in >> string{ sub };
       if (!in)
@@ -108,6 +125,11 @@ void poly::ioUI(std::vector<Polygon>& vector, std::istream& in, std::ostream& ou
     }
     else if (operation == "MIN")
     {
+      if (vector.empty())
+      {
+        throw std::logic_error("invalid cmd");
+        return;
+      }
       std::string sub;
       in >> string{ sub };
       if (!in)
@@ -157,7 +179,14 @@ void poly::ioUI(std::vector<Polygon>& vector, std::istream& in, std::ostream& ou
         try
         {
           int num{ std::stoi(sub) };
-          out << countSpec(vector, num) << '\n';
+          if (num>2)
+          {
+            out << countSpec(vector, num) << '\n';
+          }
+          else
+          {
+            throw std::invalid_argument("smol");
+          }
         }
         catch(const std::invalid_argument& ex)
         {
@@ -168,9 +197,14 @@ void poly::ioUI(std::vector<Polygon>& vector, std::istream& in, std::ostream& ou
     }
     else if (operation == "RMECHO")
     {
+      if (vector.empty())
+      {
+        throw std::logic_error("invalid cmd");
+        return;
+      }
       Polygon polygon;
       in >> polygon;
-      if (!in)
+      if (!in || polygon.polygon_.empty())
       {
         in.setstate(std::ios::failbit);
         throw std::logic_error("invalid cmd");
@@ -181,9 +215,14 @@ void poly::ioUI(std::vector<Polygon>& vector, std::istream& in, std::ostream& ou
     }
     else if (operation == "SAME")
     {
+      if (vector.empty())
+      {
+        throw std::logic_error("invalid cmd");
+        return;
+      }
       Polygon polygon;
       in >> polygon;
-      if (!in)
+      if (!in || polygon.polygon_.empty())
       {
         in.setstate(std::ios::failbit);
         throw std::logic_error("invalid cmd");

--- a/kottsov.daniil/T3/operations.cpp
+++ b/kottsov.daniil/T3/operations.cpp
@@ -43,11 +43,6 @@ void poly::ioUI(std::vector<Polygon>& vector, std::istream& in, std::ostream& ou
     }
     if (operation == "AREA")
     {
-      if (vector.empty())
-      {
-        throw std::logic_error("invalid cmd");
-        return;
-      }
       std::string sub;
       in >> string{ sub };
       if (!in)
@@ -68,6 +63,11 @@ void poly::ioUI(std::vector<Polygon>& vector, std::istream& in, std::ostream& ou
       }
       else if (sub == "MEAN")
       {
+        if (vector.empty())
+        {
+          throw std::logic_error("invalid cmd");
+          return;
+        }
         out << std::setprecision(1) << std::fixed << getMeanArea(vector) << '\n';
         return;
       }

--- a/kottsov.daniil/T3/operations.h
+++ b/kottsov.daniil/T3/operations.h
@@ -1,0 +1,32 @@
+#include "polygon.h"
+#include <map>
+#include <functional>
+#include <string>
+#include <iomanip>
+#include <exception>
+#include <cctype>
+#include <limits>
+
+#ifndef OPERATIONS
+#define OPERATIONS
+namespace poly
+{
+  struct ExpressionIO
+  {
+    std::string& ref;
+  };
+  std::istream& operator>>(std::istream& in, ExpressionIO&& exp);
+  void ioUI(std::vector<Polygon>& vector, std::istream& in, std::ostream& out);
+  double getTotalArea(const std::vector<Polygon>& vector, bool type);
+  double getMeanArea(const std::vector<Polygon>& vector);
+  double getSpecArea(const std::vector<Polygon>& vector, size_t num);
+  double getMaxArea(const std::vector<Polygon>& vector);
+  size_t getMaxVert(const std::vector<Polygon>& vector);
+  double getMinArea(const std::vector<Polygon>& vector);
+  size_t getMinVert(const std::vector<Polygon>& vector);
+  size_t countTotal(const std::vector<Polygon>& vector, bool type);
+  size_t countSpec(const std::vector<Polygon>& vector, size_t num);
+  size_t rmecho(std::vector<Polygon>& vector, const Polygon& plg);
+  size_t same(const std::vector<Polygon>& vector, const Polygon& plg);
+};
+#endif

--- a/kottsov.daniil/T3/polygon.cpp
+++ b/kottsov.daniil/T3/polygon.cpp
@@ -58,10 +58,9 @@ namespace poly
     {
       return in;
     }
-    int ofVert = 0;
+    size_t ofVert = 0;
     {
       using number = NumberInput;
-      using expr = DefInput;
       in >> number{ ofVert };
       if (!in || ofVert<=2)
       {

--- a/kottsov.daniil/T3/polygon.cpp
+++ b/kottsov.daniil/T3/polygon.cpp
@@ -72,7 +72,7 @@ namespace poly
       Point ipoint;
       std::vector<Point> ivector;
       for (size_t i = 0; i<ofVert; i++)
-      { 
+      {
         if (in >> ipoint)
         {
           ivector.push_back(ipoint);
@@ -172,7 +172,7 @@ namespace poly
     }
     return in >> num.ref;
   }
-  iofmtguard::iofmtguard(std::basic_ios<char>& s) :
+  iofmtguard::iofmtguard(std::basic_ios<char>& s):
     s_(s),
     fill_(s.fill()),
     precision_(s.precision()),

--- a/kottsov.daniil/T3/polygon.cpp
+++ b/kottsov.daniil/T3/polygon.cpp
@@ -17,24 +17,16 @@ namespace poly
     {
       return in;
     }
-    in >> DefInput{ '(' } >> point.x_;
-    in >> DefInput{ ';' } >> point.y_ >> DefInput{ ')' };
-    if (!in)
+    int x = 0;
+    int y = 0;
+    in >> DefInput{ '(' } >> x;
+    in >> DefInput{ ';' } >> y >> DefInput{ ')' };
+    if (in)
     {
-      in.setstate(std::ios::failbit);
-      throw std::logic_error("invalid cmd");
-      return in;
+      point.x_ = x;
+      point.y_ = y;
     }
     return in;
-  }
-  std::istream& operator>>(std::istream& in, PointIO&& ptr)
-  {
-    std::istream::sentry ward(in);
-    if (!ward)
-    {
-      return in;
-    }
-    return in >> ptr.ref;
   }
   bool operator==(const Point& first, const Point& second)
   {
@@ -65,16 +57,25 @@ namespace poly
       if (!in || ofVert<=2)
       {
         in.setstate(std::ios::failbit);
-        throw std::logic_error("invalid cmd");
         return in;
       }
       Point ipoint;
       std::vector<Point> ivector;
       for (size_t i = 0; i<ofVert; i++)
       {
+        if (in.peek()!=' ')
+        {
+          in.setstate(std::ios::failbit);
+          return in;
+        }
         if (in >> ipoint)
         {
           ivector.push_back(ipoint);
+        }
+        else
+        {
+          in.setstate(std::ios::failbit);
+          return in;
         }
       }
       if (in && ivector.size() == ofVert && (in.get() == '\n'))
@@ -83,7 +84,6 @@ namespace poly
       }
       else
       {
-        throw std::logic_error("how did you even do that");
         in.setstate(std::ios::failbit);
         return in;
       }

--- a/kottsov.daniil/T3/polygon.cpp
+++ b/kottsov.daniil/T3/polygon.cpp
@@ -22,7 +22,7 @@ namespace poly
     if (!in)
     {
       in.setstate(std::ios::failbit);
-      throw std::logic_error("invalid input");
+      throw std::logic_error("invalid cmd");
       return in;
     }
     return in;
@@ -65,7 +65,7 @@ namespace poly
       if (!in || ofVert<=2)
       {
         in.setstate(std::ios::failbit);
-        throw std::logic_error("invalid input");
+        throw std::logic_error("invalid cmd");
         return in;
       }
       Point ipoint;
@@ -83,7 +83,7 @@ namespace poly
       }
       else
       {
-        throw std::logic_error("errored");
+        throw std::logic_error("how did you even do that");
         in.setstate(std::ios::failbit);
         return in;
       }
@@ -125,16 +125,16 @@ namespace poly
     {
       double operator()(const Point& point1, const Point& point2)
       {
-        return std::abs((point2.x_*point1.y_)-(point2.y_*point1.x_));
+        return std::fabs((point1.x_*point2.y_)-(point1.y_*point2.x_));
       }
     };
     std::vector<double> subAreas(polygon.polygon_.size());
     std::transform(
-      ++polygon.polygon_.begin(),
-      polygon.polygon_.end(),
-      polygon.polygon_.begin(),
+      ++polygon.polygon_.cbegin(),
+      polygon.polygon_.cend(),
+      polygon.polygon_.cbegin(),
       subAreas.begin(),
-      std::bind(determine(),std::placeholders::_1,std::placeholders::_2)
+      std::bind(determine(),std::placeholders::_2,std::placeholders::_1)
     );
     double area = std::accumulate(
       subAreas.begin(),
@@ -145,7 +145,7 @@ namespace poly
       polygon.polygon_[polygon.polygon_.size()-1],
       polygon.polygon_[0]
     );
-    return std::abs((area + wrapped)) / 2.0;
+    return std::fabs((area - wrapped)) / 2.0;
   }
   std::istream& operator>>(std::istream& in, DefInput&& def)
   {

--- a/kottsov.daniil/T3/polygon.cpp
+++ b/kottsov.daniil/T3/polygon.cpp
@@ -1,0 +1,187 @@
+#include "polygon.h"
+
+namespace poly
+{
+  Point::Point():
+    x_(0),
+    y_(0)
+  {};
+  Point::Point(int x, int y):
+    x_(x),
+    y_(y)
+  {};
+  std::istream& operator>>(std::istream& in, Point& point)
+  {
+    std::istream::sentry ward(in);
+    if (!ward)
+    {
+      return in;
+    }
+    in >> DefInput{ '(' } >> point.x_;
+    in >> DefInput{ ';' } >> point.y_ >> DefInput{ ')' };
+    if (!in)
+    {
+      in.setstate(std::ios::failbit);
+      throw std::logic_error("invalid input");
+      return in;
+    }
+    return in;
+  }
+  std::istream& operator>>(std::istream& in, PointIO&& ptr)
+  {
+    std::istream::sentry ward(in);
+    if (!ward)
+    {
+      return in;
+    }
+    return in >> ptr.ref;
+  }
+  bool operator==(const Point& first, const Point& second)
+  {
+    return (first.x_==second.x_) && (first.y_==second.y_);
+  }
+  std::ostream& operator<<(std::ostream& out, const Point& point)
+  {
+    std::ostream::sentry ward(out);
+    iofmtguard guard(out);
+    if (!ward)
+    {
+      return out;
+    }
+    out << '(' << point.x_ << ';' << point.y_ << ')';
+    return out;
+  }
+  std::istream& operator>>(std::istream& in, Polygon& polyg)
+  {
+    std::istream::sentry ward(in);
+    if (!ward)
+    {
+      return in;
+    }
+    int ofVert = 0;
+    {
+      using number = NumberInput;
+      using expr = DefInput;
+      in >> number{ ofVert };
+      if (!in || ofVert<=2)
+      {
+        in.setstate(std::ios::failbit);
+        throw std::logic_error("invalid input");
+        return in;
+      }
+      Point ipoint;
+      std::vector<Point> ivector;
+      for (size_t i = 0; i<ofVert; i++)
+      { 
+        if (in >> ipoint)
+        {
+          ivector.push_back(ipoint);
+        }
+      }
+      if (in && ivector.size() == ofVert && (in.get() == '\n'))
+      {
+        polyg = Polygon{ ivector };
+      }
+      else
+      {
+        throw std::logic_error("errored");
+        in.setstate(std::ios::failbit);
+        return in;
+      }
+    }
+    return in;
+  }
+  std::ostream& operator<<(std::ostream& out, const Polygon& polyg)
+  {
+    std::ostream::sentry ward(out);
+    if (!ward)
+    {
+      return out;
+    }
+    iofmtguard guard(out);
+    for (Point i : polyg.polygon_)
+    {
+      out << i << ' ';
+    }
+    return out;
+  }
+  bool operator==(const Polygon& first, const Polygon& second)
+  {
+    if (first.polygon_.size()!=second.polygon_.size())
+    {
+      return false;
+    }
+    for (size_t i = 0; i<first.polygon_.size(); i++)
+    {
+      if (!(first.polygon_[i]==second.polygon_[i]))
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+  double getPolyArea(const Polygon& polygon)
+  {
+    struct determine
+    {
+      double operator()(const Point& point1, const Point& point2)
+      {
+        return std::abs((point2.x_*point1.y_)-(point2.y_*point1.x_));
+      }
+    };
+    std::vector<double> subAreas(polygon.polygon_.size());
+    std::transform(
+      ++polygon.polygon_.begin(),
+      polygon.polygon_.end(),
+      polygon.polygon_.begin(),
+      subAreas.begin(),
+      std::bind(determine(),std::placeholders::_1,std::placeholders::_2)
+    );
+    double area = std::accumulate(
+      subAreas.begin(),
+      subAreas.end(),
+      0.0
+    );
+    double wrapped = determine()(
+      polygon.polygon_[polygon.polygon_.size()-1],
+      polygon.polygon_[0]
+    );
+    return std::abs((area + wrapped)) / 2.0;
+  }
+  std::istream& operator>>(std::istream& in, DefInput&& def)
+  {
+    std::istream::sentry ward(in);
+    if (!ward)
+    {
+      return in;
+    }
+    char c = '0';
+    in >> c;
+    if (in && (c != def.exp))
+    {
+      in.setstate(std::ios::failbit);
+    }
+    return in;
+  }
+  std::istream& operator>>(std::istream& in, NumberInput&& num)
+  {
+    std::istream::sentry ward(in);
+    if (!ward)
+    {
+      return in;
+    }
+    return in >> num.ref;
+  }
+  iofmtguard::iofmtguard(std::basic_ios<char>& s) :
+    s_(s),
+    fill_(s.fill()),
+    precision_(s.precision()),
+    fmt_(s.flags())
+  {};
+  iofmtguard::~iofmtguard()
+  {
+    s_.fill(fill_);
+    s_.precision(precision_);
+    s_.flags(fmt_);
+  }
+}

--- a/kottsov.daniil/T3/polygon.h
+++ b/kottsov.daniil/T3/polygon.h
@@ -29,12 +29,7 @@ namespace poly
     int x_;
     int y_;
   };
-  struct PointIO
-  {
-    Point& ref;
-  };
   std::istream& operator>>(std::istream& in, Point& point);
-  std::istream& operator>>(std::istream& in, PointIO&& ptr);
   std::ostream& operator<<(std::ostream& out, const Point& point);
   bool operator==(const Point& first, const Point& second);
   struct Polygon

--- a/kottsov.daniil/T3/polygon.h
+++ b/kottsov.daniil/T3/polygon.h
@@ -52,7 +52,7 @@ namespace poly
   std::istream& operator>>(std::istream& in, DefInput&& def);
   struct NumberInput
   {
-    int& ref;
+    size_t& ref;
   };
   std::istream& operator>>(std::istream& in, NumberInput&& num);
 };

--- a/kottsov.daniil/T3/polygon.h
+++ b/kottsov.daniil/T3/polygon.h
@@ -1,0 +1,59 @@
+#include <algorithm>
+#include <iterator>
+#include <iostream>
+#include <vector>
+#include <cmath>
+#include <functional>
+#include <numeric>
+
+#ifndef POLYGON
+#define POLYGON
+// RMECHO SAME
+namespace poly
+{
+  class iofmtguard
+  {
+    public:
+      iofmtguard(std::basic_ios<char>& s);
+      ~iofmtguard();
+    private:
+      std::basic_ios<char>& s_;
+      char fill_;
+      std::streamsize precision_;
+      std::basic_ios<char>::fmtflags fmt_;
+  };
+  struct Point
+  {
+    Point();
+    Point(int x, int y);
+    int x_;
+    int y_;
+  };
+  struct PointIO
+  {
+    Point& ref;
+  };
+  std::istream& operator>>(std::istream& in, Point& point);
+  std::istream& operator>>(std::istream& in, PointIO&& ptr);
+  std::ostream& operator<<(std::ostream& out, const Point& point);
+  bool operator==(const Point& first, const Point& second);
+  struct Polygon
+  {
+    std::vector<Point> polygon_;
+  };
+  std::istream& operator>>(std::istream& in, Polygon& polyg);
+  std::ostream& operator<<(std::ostream& out, const Polygon& polyg);
+  bool operator==(const Polygon& first, const Polygon& second);
+  double getPolyArea(const Polygon& polygon);
+  struct DefInput
+  {
+    char exp;
+  };
+  std::istream& operator>>(std::istream& in, DefInput&& def);
+  struct NumberInput
+  {
+    int& ref;
+  };
+  std::istream& operator>>(std::istream& in, NumberInput&& num);
+};
+#endif


### PR DESCRIPTION
changelog (kinda):
1.0 - implemented all of the base and 2 extra (RMECHO & SAME) operations
1.0.1 - removed tailing spaces
1.0.2 - removed deprecated aliases for input structures and fixed narrowing conversion issues
1.0.3 - fixed being unable to input an empty file
1.1 - fixed area calculations using Gauss method, now invalidates operations with invalid number of vertexes
1.1.1 - was lost to the history (i forgot)
1.1.2 - now input operators don't generate exceptions, removed deprecated input-output structure for Point, added extra checks for ios::failbit